### PR TITLE
Add option to embed the stylesheet

### DIFF
--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -21,7 +21,7 @@ defmodule ExCSSModules do
   def stylesheet(definition) when is_map(definition), do: definition
 
   @doc false
-  def stylesheet(definition), do: definition |> read_stylesheet()
+  def stylesheet(definition), do: read_stylesheet(definition)
 
   def read_stylesheet(filename) do
     case File.exists?(filename) do

--- a/lib/ex_css_modules/view.ex
+++ b/lib/ex_css_modules/view.ex
@@ -18,7 +18,8 @@ defmodule ExCSSModules.View do
   """
 
   defmacro __using__(opts \\ []) do
-    {file, [file: relative_to]} = Code.eval_quoted(opts[:stylesheet], file: __CALLER__.file)
+    {file, [file: relative_to]} =
+      Code.eval_quoted(opts[:stylesheet], file: __CALLER__.file)
 
     file = Path.expand(file, Path.dirname(relative_to))
 

--- a/lib/ex_css_modules/view.ex
+++ b/lib/ex_css_modules/view.ex
@@ -7,6 +7,8 @@ defmodule ExCSSModules.View do
   Use the ExCSSModules.View on a view which defines the JSON for CSS Modules
   as an external resource.
 
+  To embed the stylesheet in the file set :embed_stylesheet to true.
+
   If adds the following functions to the View:
   - stylesheet/0 - same as ExCSSModules.stylesheet/1 with the stylesheet predefined
   - class/1 - same as ExCSSModules.class/2 with the stylesheet predefined
@@ -14,20 +16,34 @@ defmodule ExCSSModules.View do
   - class_name/2 - same as ExCSSModules.class_name/3 with the stylesheet predefined
   - class_selector/1 - same as ExCSSModules.class_selector/2 with the stylesheet predefined
   """
+
   defmacro __using__(opts \\ []) do
+    {file, [file: relative_to]} = Code.eval_quoted(opts[:stylesheet], file: __CALLER__.file)
+
+    file = Path.expand(file, Path.dirname(relative_to))
+
     quote do
-      @external_resource unquote(opts[:stylesheet]) <> ".json"
-      @stylesheet ExCSSModules.read_stylesheet(unquote(opts[:stylesheet]))
+      @stylesheet unquote(
+        if opts[:embed_stylesheet] do
+          Macro.escape(ExCSSModules.read_stylesheet(file))
+        else
+          Macro.escape(file)
+        end
+      )
+
+      def stylesheet_definition, do: @stylesheet
 
       def stylesheet, do: ExCSSModules.stylesheet(@stylesheet)
 
-      def class(key), do: ExCSSModules.class(@stylesheet, key)
+      def class(key), do: stylesheet() |> ExCSSModules.class(key)
 
-      def class_name(key), do: ExCSSModules.class_name(@stylesheet, key)
+      def class_name(key) do
+        ExCSSModules.class_name(stylesheet(), key)
+      end
       def class_name(key, value), do:
-        ExCSSModules.class_name(@stylesheet, key, value)
+        ExCSSModules.class_name(stylesheet(), key, value)
 
-      def class_selector(key), do: ExCSSModules.class_selector(@stylesheet, key)
+      def class_selector(key), do: ExCSSModules.class_selector(stylesheet(), key)
     end
   end
 end

--- a/test/ex_css_modules/view_test.exs
+++ b/test/ex_css_modules/view_test.exs
@@ -7,14 +7,33 @@ defmodule ExCSSModules.ViewTest do
 
   defmodule ViewModuleTest do
     use ExCSSModules.View, stylesheet: __ENV__.file
-                                      |> Path.dirname
-                                      |> Path.join("../support/stylesheet.css")
+                                       |> Path.dirname
+                                       |> Path.join("../support/stylesheet.css")
+  end
 
+  defmodule EmbeddedViewModuleTest do
+    use ExCSSModules.View, stylesheet: __ENV__.file
+                                       |> Path.dirname
+                                       |> Path.join("../support/stylesheet.css"),
+                           embed_stylesheet: true
+  end
+
+  describe "stylesheet_definition/0" do
+    test "gets the stylesheet string" do
+      assert ViewModuleTest.stylesheet_definition
+        == Path.expand(@example_stylesheet)
+    end
+
+    test "gets the embedded stylesheet" do
+      assert EmbeddedViewModuleTest.stylesheet_definition
+        == ExCSSModules.stylesheet(@example_stylesheet)
+    end
   end
 
   describe "stylesheet/0" do
     test "calls the stylesheet" do
-      assert ViewModuleTest.stylesheet == ExCSSModules.stylesheet(@example_stylesheet)
+      assert ViewModuleTest.stylesheet
+        == ExCSSModules.stylesheet(@example_stylesheet)
     end
   end
 


### PR DESCRIPTION
Instead of compiling the stylesheets into view by default it's now an option. This decreases the initial and recompile compile time of views when developing the application and saving CSS files:

```
Compiling lib/myapp_web/views/course/index/view.ex (it's taking more than 10s)
Compiling lib/myapp_web/controllers/registration_controller.ex (it's taking more than 10s)
Compiling lib/myapp_web/cells/badge/view.ex (it's taking more than 10s)
Compiling lib/myapp_web/cells/departments/employee_list/view.ex (it's taking more than 10s)
Compiling lib/myapp_web/cells/navigation/main_desktop/view.ex (it's taking more than 10s)
Compiling lib/myapp_web/views/user/edit/view.ex (it's taking more than 10s)
Compiling lib/myapp_web/views/position/show/view.ex (it's taking more than 10s)
```