### PR TITLE
Expand embed option to allow evaluated code

### DIFF
--- a/lib/ex_css_modules/view.ex
+++ b/lib/ex_css_modules/view.ex
@@ -18,17 +18,20 @@ defmodule ExCSSModules.View do
   """
 
   defmacro __using__(opts \\ []) do
-    {file, [file: relative_to]} =
+    {filename, [file: relative_to]} =
       Code.eval_quoted(opts[:stylesheet], file: __CALLER__.file)
 
-    file = Path.expand(file, Path.dirname(relative_to))
+    {embed, _} =
+      Code.eval_quoted(opts[:embed_stylesheet])
+
+    filename = Path.expand(filename, Path.dirname(relative_to))
 
     quote do
       @stylesheet unquote(
-        if opts[:embed_stylesheet] do
-          Macro.escape(ExCSSModules.read_stylesheet(file))
+        if embed do
+          Macro.escape(ExCSSModules.read_stylesheet(filename))
         else
-          Macro.escape(file)
+          Macro.escape(filename)
         end
       )
 


### PR DESCRIPTION
The embed option works fine if you use `true` or `false` as values as they are values by definition, if you however use something like `Mix.env == :prod` the code is treated as a quoted value which is always truthy resulting in an AST tree:

```ex
{:{}, [],
 [:==, [context: DetroitWeb, import: Kernel, line: 6],
  [{:{}, [],
    [{:{}, [],
      [:., [line: 6],
       [{:{}, [],
         [:__aliases__, [alias: false, counter: -576460752303420796, line: 6],
          [:Mix]]}, :env]]}, [line: 6], []]}, :prod]]}
```

By evaluating the condition things like `Mix.env` can be used to set the value.