### PR TITLE
Move tests to doctests

### DIFF
--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -101,35 +101,41 @@ defmodule ExCSSModules do
   def class_name(_, _, false), do: nil
 
   @doc """
-  Returns the class name from the definition map if the second argument
-  in the tuple is true.
+  Returns the class name or class names from the definition map, concatenated as
+  one string separated by spaces.
+
+  Second argument can be a string name of the key, a tuple with `{key, boolean}`
+  or a list of keys or tuples.
 
   ## Examples
-    iex> class_name(%{"hello" => "world"}, {"hello", true})
-    "world"
 
-    iex> class_name(%{"hello" => "world"}, {"hello", false})
-    nil
-  """
-  def class_name(definition, {key, value}), do:
-    class_name(definition, key, value)
+      iex> class_name(%{"hello" => "world"}, "hello")
+      "world"
 
-  @doc """
-  Returns the class name sfrom the definition map when the argument is a list
-  of values or tuples.
+      iex> class_name(%{"hello" => "world"}, "foo")
+      nil
 
-  ## Examples
-    iex> class_name(%{"hello" => "world", "foo" => "bar"}, ["hello", "foo"])
-    "world bar"
+      iex> class_name(%{"hello" => "world"}, {"hello", true})
+      "world"
 
-    iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", true}, {"foo", true}])
-    "world bar"
+      iex> class_name(%{"hello" => "world"}, {"hello", false})
+      nil
 
-    iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", true}, {"foo", false}])
-    "world"
+      iex> class_name(%{"hello" => "world", "foo" => "bar"}, ["hello", "foo"])
+      "world bar"
 
-    iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", false}])
-    nil
+      iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", true}, {"foo", true}])
+      "world bar"
+
+      iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", true}, {"foo", false}])
+      "world"
+
+      iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", false}])
+      nil
+
+      iex> class_name(%{}, "hello")
+      nil
+
   """
   def class_name(definition, keys) when is_list(keys) do
     keys
@@ -138,19 +144,10 @@ defmodule ExCSSModules do
     |> join_class_name()
   end
 
-  @doc """
-  Returns the class name sfrom the definition map when the argument is a list
-  of values or tuples.
+  def class_name(definition, {key, return_class?}), do: class_name(definition, key, return_class?)
 
-  ## Examples
-    iex> class_name(%{"hello" => "world"}, "hello")
-    "world"
-
-    iex> class_name(%{"hello" => "world"}, "foo")
-    nil
-  """
-  def class_name(stylesheet, key) do
-    stylesheet
+  def class_name(definition, key) do
+    definition
     |> stylesheet()
     |> Map.get(key, nil)
   end

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -85,20 +85,27 @@ defmodule ExCSSModules do
   end
 
   @doc """
-  Returns the class name from the definition map if the last argument is true.
-  Returns nil if the last argument is false.
+  Returns the class name from the definition map if the last argument is truthy.
+  Returns nil if the last argument is falsy.
 
   ## Examples
 
       iex> class_name(%{"hello" => "world"}, "hello", true)
       "world"
 
+      iex> class_name(%{"hello" => "world"}, "hello", "anything")
+      "world"
+
       iex> class_name(%{"hello" => "world"}, "hello", false)
       nil
 
+      iex> class_name(%{"hello" => "world"}, "hello", nil)
+      nil
+
   """
-  def class_name(definition, key, true), do: class_name(definition, key)
   def class_name(_, _, false), do: nil
+  def class_name(_, _, nil), do: nil
+  def class_name(definition, key, _), do: class_name(definition, key)
 
   @doc """
   Returns the class name or class names from the definition map, concatenated as

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -83,20 +83,20 @@ defmodule ExCSSModules do
   end
 
   @doc """
-  Returns the class name from the definition map if value is true.
+  Returns the class name from the definition map if the last argument is true.
+  Returns nil if the last argument is false.
 
   ## Examples
-    iex> class_name(%{"hello" => "world"}, "hello", true)
-    "world"
 
-    iex> class_name(%{"hello" => "world"}, "hello", false)
-    nil
+      iex> class_name(%{"hello" => "world"}, "hello", true)
+      "world"
+
+      iex> class_name(%{"hello" => "world"}, "hello", false)
+      nil
+
   """
-  def class_name(definition, key, value) do
-    if value do
-      class_name(definition, key)
-    end
-  end
+  def class_name(definition, key, true), do: class_name(definition, key)
+  def class_name(_, _, false), do: nil
 
   @doc """
   Returns the class name from the definition map if the second argument

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -45,11 +45,19 @@ defmodule ExCSSModules do
 
   @doc """
   Reads the class definitions from the definition map and maps them to a class
-  attribute. The classes argument takes any argument the class_name for the key.
+  attribute. The classes argument takes any argument and uses the class_name/1
+  for the key.
+
+  Returns nil for a class_name that does not exist.
 
   ## Examples
-    iex> class(%{ "hello" => "world"}, "hello")
-    {:safe, ~s(class="world")}
+
+      iex> class(%{ "hello" => "world"}, "hello")
+      {:safe, ~s(class="world")}
+
+      iex> class(%{"hello" => "world"}, "foo")
+      nil
+
   """
   def class(definition, classes) do
     definition

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -2,33 +2,44 @@ defmodule ExCSSModules do
   @moduledoc """
   CSS Modules helpers
   """
-
   alias __MODULE__
   alias Phoenix.HTML
 
   @doc """
-  Reads the stylesheet. Returns a map if the stylesheet is already a map. Reads
-  the file if the stylesheet is a string.
+  Reads a valid stylesheet definition. Returns a map if the stylesheet is
+  already a map. Reads the file if the stylesheet is a string. Returns an empty
+  map if the stylesheet does not exist.
 
   ## Examples
 
-    iex> stylesheet(%{})
-    %{}
+      iex> stylesheet(@example_stylesheet)
+      %{
+        "title" => "_namespaced_title",
+        "paragraph" => "_namespaced_paragraph"
+      }
 
-    iex> stylesheet("../stylesheet.css")
-    %{}
+      iex> stylesheet(%{"title" => "_namespaced_title", "paragraph" => "_namespaced_paragraph"})
+      %{
+        "title" => "_namespaced_title",
+        "paragraph" => "_namespaced_paragraph"
+      }
+
+      iex> stylesheet("foobar")
+      %{}
+
   """
   def stylesheet(definition) when is_map(definition), do: definition
-
-  @doc false
   def stylesheet(definition), do: read_stylesheet(definition)
 
-  def read_stylesheet(filename) do
+  defp read_stylesheet(filename) do
     case File.exists?(filename) do
-      true -> filename <> ".json"
-              |> File.read!
-              |> Poison.decode!
-      false -> %{}
+      true ->
+        (filename <> ".json")
+        |> File.read!()
+        |> Poison.decode!()
+
+      false ->
+        %{}
     end
   end
 

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -154,31 +154,40 @@ defmodule ExCSSModules do
 
   @doc """
   Takes the definition and makes a class selector that can be used in CSS out of
-  the classes given. Takes either a single value or a list of classes.
+  the keys given. Takes either a single value or a list of keys.
 
   ## Examples
-    iex> class_selector(%{ "hello" => "world"}, "hello")
-    ".world"
-    iex> class_selector(%{ "hello" => "world", "foo" => "bar"}, ["hello", "foo"])
-    ".world.foo"
+
+      iex> class_selector(@example_stylesheet, "title")
+      "._namespaced_title"
+
+      iex> class_selector(@example_stylesheet, ["title", "paragraph"])
+      "._namespaced_title._namespaced_paragraph"
+
+      iex> class_selector(@example_stylesheet, "foo")
+      nil
+
+      iex> class_selector(%{ "hello" => "world"}, "hello")
+      ".world"
+
+      iex> class_selector(%{ "hello" => "world", "foo" => "bar"}, ["hello", "foo"])
+      ".world.bar"
+
   """
-  def class_selector(definition, classes) when is_list(classes) do
-    classes
+  def class_selector(definition, keys) when is_list(keys) do
+    keys
     |> Enum.map(&class_selector(definition, &1))
     |> Enum.reject(&is_nil/1)
-    |> Enum.join("")
+    |> List.to_string()
   end
 
-  @doc false
-  def class_selector(definition, class) do
-    case class_name(definition, class) do
-      nil -> nil
-      value -> ".#{value}"
-    end
-  end
+  def class_selector(definition, key), do: definition |> class_name(key) |> class_selector()
 
+  defp class_selector(class) when is_binary(class), do: ".#{class}"
+  defp class_selector(nil), do: nil
+
+  defp class_attribute(class) when is_binary(class), do: HTML.raw(~s(class="#{class}"))
   defp class_attribute(nil), do: nil
-  defp class_attribute(class), do: HTML.raw(~s(class="#{class}"))
 
   defp join_class_name([_ | _] = list), do: Enum.join(list, " ")
   defp join_class_name([]), do: nil

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -45,8 +45,8 @@ defmodule ExCSSModules do
 
   @doc """
   Reads the class definitions from the definition map and maps them to a class
-  attribute. The classes argument takes any argument and uses the class_name/1
-  for the key.
+  attribute. The `keys` argument is used to retrieve the class name or multiple
+  class names with class_name/1.
 
   Returns nil for a class_name that does not exist.
 
@@ -59,26 +59,28 @@ defmodule ExCSSModules do
       nil
 
   """
-  def class(definition, classes) do
+  def class(definition, keys) do
     definition
-    |> class_name(classes)
+    |> class_name(keys)
     |> class_attribute()
   end
 
   @doc """
-  If `value` is truthy, read the class definitions and maps them to a class attribute.
-  When `value` is falsy return nil.
+  If `return_class?` is truthy, reads the class definitions and maps them to a
+  class attribute. When `return_class?` is falsy returns nil.
 
   ## Examples
-    iex> class(%{ "hello" => "world"}, "hello", true)
-    {:safe, ~s(class="world")}
 
-    iex> class(%{ "hello" => "world"}, "hello", false)
-    nil
+      iex> class(%{ "hello" => "world"}, "hello", true)
+      {:safe, ~s(class="world")}
+
+      iex> class(%{ "hello" => "world"}, "hello", false)
+      nil
+
   """
-  def class(definition, classes, value) do
+  def class(definition, keys, return_class?) do
     definition
-    |> class_name(classes, value)
+    |> class_name(keys, return_class?)
     |> class_attribute()
   end
 

--- a/lib/ex_css_modules/view.ex
+++ b/lib/ex_css_modules/view.ex
@@ -25,7 +25,7 @@ defmodule ExCSSModules.View do
     quote do
       @stylesheet unquote(
                     if embed do
-                      Macro.escape(ExCSSModules.read_stylesheet(filename))
+                      Macro.escape(ExCSSModules.stylesheet(filename))
                     else
                       Macro.escape(filename)
                     end

--- a/lib/ex_css_modules/view.ex
+++ b/lib/ex_css_modules/view.ex
@@ -18,22 +18,18 @@ defmodule ExCSSModules.View do
   """
 
   defmacro __using__(opts \\ []) do
-    {filename, [file: relative_to]} =
-      Code.eval_quoted(opts[:stylesheet], file: __CALLER__.file)
-
-    {embed, _} =
-      Code.eval_quoted(opts[:embed_stylesheet])
-
+    {filename, [file: relative_to]} = Code.eval_quoted(opts[:stylesheet], file: __CALLER__.file)
+    {embed, _} = Code.eval_quoted(opts[:embed_stylesheet])
     filename = Path.expand(filename, Path.dirname(relative_to))
 
     quote do
       @stylesheet unquote(
-        if embed do
-          Macro.escape(ExCSSModules.read_stylesheet(filename))
-        else
-          Macro.escape(filename)
-        end
-      )
+                    if embed do
+                      Macro.escape(ExCSSModules.read_stylesheet(filename))
+                    else
+                      Macro.escape(filename)
+                    end
+                  )
 
       def stylesheet_definition, do: @stylesheet
 
@@ -42,13 +38,10 @@ defmodule ExCSSModules.View do
       def class(key), do: stylesheet() |> ExCSSModules.class(key)
       def class(key, value), do: stylesheet() |> ExCSSModules.class(key, value)
 
-      def class_name(key) do
-        ExCSSModules.class_name(stylesheet(), key)
-      end
-      def class_name(key, value), do:
-        ExCSSModules.class_name(stylesheet(), key, value)
+      def class_name(key), do: stylesheet() |> ExCSSModules.class_name(key)
+      def class_name(key, value), do: stylesheet() |> ExCSSModules.class_name(key, value)
 
-      def class_selector(key), do: ExCSSModules.class_selector(stylesheet(), key)
+      def class_selector(key), do: stylesheet() |> ExCSSModules.class_selector(key)
     end
   end
 end

--- a/test/ex_css_modules/ex_css_modules_test.exs
+++ b/test/ex_css_modules/ex_css_modules_test.exs
@@ -7,61 +7,6 @@ defmodule ExCSSModulesTest do
 
   doctest ExCSSModules, import: true
 
-  describe "class_name/2" do
-    test "use class_name/3 when the key is a tuple" do
-      assert ExCSSModules.class_name(%{"hello" => "world"}, "hello", true) ==
-        ExCSSModules.class_name(%{"hello" => "world"}, {"hello", true})
-
-      assert ExCSSModules.class_name(%{"hello" => "world"}, "hello", false) ==
-        ExCSSModules.class_name(%{"hello" => "world"}, {"hello", false})
-    end
-
-    test "accepts a list of values" do
-      assert ExCSSModules.class_name(
-        %{"hello" => "world", "foo" => "bar"},
-        ["hello", "foo"]
-      ) == "world bar"
-    end
-
-    test "accepts a list of tuples" do
-      assert ExCSSModules.class_name(
-        %{"hello" => "world", "foo" => "bar"},
-        [{"hello", false}, {"foo", true}]
-      ) == "bar"
-    end
-
-    test "returns the value" do
-      assert ExCSSModules.class_name(
-        %{"hello" => "world", "foo" => "bar"},
-        "hello"
-      ) == "world"
-    end
-
-    test "returns nil for an existing classname when value is false" do
-      assert ExCSSModules.class_name(
-        %{"hello" => "world", "foo" => "bar"},
-        [{"hello", false}]
-      ) == nil
-    end
-
-    test "defaults to nil" do
-      assert ExCSSModules.class_name(%{}, "hello") == nil
-    end
-  end
-
-  describe "class_name/1" do
-    test "returns a map if given a map" do
-      assert ExCSSModules.stylesheet(%{}) == %{}
-    end
-
-    test "reads a file if given a string" do
-      assert ExCSSModules.stylesheet(@example_stylesheet) == %{
-        "title" => "_namespaced_title",
-        "paragraph" => "_namespaced_paragraph"
-      }
-    end
-  end
-
   describe "class_selector/2" do
     test "returns the selector if the key is present" do
       assert ExCSSModules.class_selector(@example_stylesheet, "title")

--- a/test/ex_css_modules/ex_css_modules_test.exs
+++ b/test/ex_css_modules/ex_css_modules_test.exs
@@ -7,20 +7,6 @@ defmodule ExCSSModulesTest do
 
   doctest ExCSSModules, import: true
 
-  describe "class/3" do
-    test "returns a class attribute for an existing classname when value is true" do
-      assert ExCSSModules.class(
-        %{"hello" => "world"},
-        "hello",
-        true
-      ) == {:safe, ~s(class="world")}
-    end
-
-    test "returns nil for an existing classname when value is false" do
-      assert ExCSSModules.class(%{"hello" => "world"}, "hello", false) == nil
-    end
-  end
-
   describe "class_name/2" do
     test "use class_name/3 when the key is a tuple" do
       assert ExCSSModules.class_name(%{"hello" => "world"}, "hello", true) ==

--- a/test/ex_css_modules/ex_css_modules_test.exs
+++ b/test/ex_css_modules/ex_css_modules_test.exs
@@ -7,19 +7,6 @@ defmodule ExCSSModulesTest do
 
   doctest ExCSSModules, import: true
 
-  describe "class/2" do
-    test "returns a class attribute for an existing classname" do
-      assert ExCSSModules.class(
-        %{"hello" => "world"},
-        "hello"
-      ) == {:safe, ~s(class="world")}
-    end
-
-    test "returns nil for a non existing classname" do
-      assert ExCSSModules.class(%{"hello" => "world"}, "foo") == nil
-    end
-  end
-
   describe "class/3" do
     test "returns a class attribute for an existing classname when value is true" do
       assert ExCSSModules.class(

--- a/test/ex_css_modules/ex_css_modules_test.exs
+++ b/test/ex_css_modules/ex_css_modules_test.exs
@@ -2,22 +2,10 @@ defmodule ExCSSModulesTest do
   use ExUnit.Case
 
   @example_stylesheet __ENV__.file
-                      |> Path.dirname
+                      |> Path.dirname()
                       |> Path.join("../support/stylesheet.css")
 
-  describe "read_stylesheet/1" do
-    test "reads a valid stylesheet definition" do
-      assert ExCSSModules.read_stylesheet(@example_stylesheet) ==
-        %{
-          "title" => "_namespaced_title",
-          "paragraph" => "_namespaced_paragraph"
-        }
-    end
-
-    test "ignores an invalid stylesheet definition" do
-      assert ExCSSModules.read_stylesheet("foobar") == %{}
-    end
-  end
+  doctest ExCSSModules, import: true
 
   describe "class/2" do
     test "returns a class attribute for an existing classname" do

--- a/test/ex_css_modules/ex_css_modules_test.exs
+++ b/test/ex_css_modules/ex_css_modules_test.exs
@@ -6,21 +6,4 @@ defmodule ExCSSModulesTest do
                       |> Path.join("../support/stylesheet.css")
 
   doctest ExCSSModules, import: true
-
-  describe "class_selector/2" do
-    test "returns the selector if the key is present" do
-      assert ExCSSModules.class_selector(@example_stylesheet, "title")
-        == "._namespaced_title"
-    end
-
-    test "returns nil if the key is not present" do
-      assert ExCSSModules.class_selector(@example_stylesheet, "foo")
-        == nil
-    end
-
-    test "returns a joined string if the key is a list" do
-      assert ExCSSModules.class_selector(@example_stylesheet, ["title", "paragraph"])
-        == "._namespaced_title._namespaced_paragraph"
-    end
-  end
 end

--- a/test/ex_css_modules/ex_css_modules_test.exs
+++ b/test/ex_css_modules/ex_css_modules_test.exs
@@ -21,20 +21,6 @@ defmodule ExCSSModulesTest do
     end
   end
 
-  describe "class_name/3" do
-    test "returns the definition when value is true" do
-      assert ExCSSModules.class_name(
-        %{"hello" => "world"},
-        "hello",
-        true
-      ) == "world"
-    end
-
-    test "returns nil when value is false" do
-      assert ExCSSModules.class_name(%{"hello" => "world"}, "hello", false) == nil
-    end
-  end
-
   describe "class_name/2" do
     test "use class_name/3 when the key is a tuple" do
       assert ExCSSModules.class_name(%{"hello" => "world"}, "hello", true) ==


### PR DESCRIPTION
- Run doctests for ExCSSModules in ExCSSModulesTest
- Update some docs
- Rename some variables
- Reformat some code

This is a preparation for making `class_name` able to convert atoms to strings so atoms / atom lists can be passed to the functions here.