### PR TITLE
Make sure atoms can be passed onto class, class_name and class_selector 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             - v1-plt-cache-{{ checksum "mix.lock" }}
             - v1-plt-cache
       - run: mix dialyzer --plt
+      - run: mix dialyzer --list-unused-filters
       - save_cache:
           key: v1-plt-cache-{{ checksum "mix.lock" }}
           paths:

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -96,6 +96,9 @@ defmodule ExCSSModules do
       iex> class_name(%{"hello" => "world"}, "hello", "anything")
       "world"
 
+      iex> class_name(%{"hello" => "world"}, :hello, true)
+      "world"
+
       iex> class_name(%{"hello" => "world"}, "hello", false)
       nil
 
@@ -111,8 +114,8 @@ defmodule ExCSSModules do
   Returns the class name or class names from the definition map, concatenated as
   one string separated by spaces.
 
-  Second argument can be a string name of the key, a tuple with `{key, boolean}`
-  or a list of keys or tuples.
+  Second argument can be a string or atom name of the key, a tuple with
+  `{key, boolean}` or a list of keys or tuples.
 
   ## Examples
 
@@ -137,6 +140,9 @@ defmodule ExCSSModules do
       iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", true}, {"foo", false}])
       "world"
 
+      iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{:hello, true}, {:foo, false}])
+      "world"
+
       iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", false}])
       nil
 
@@ -152,6 +158,9 @@ defmodule ExCSSModules do
   end
 
   def class_name(definition, {key, return_class?}), do: class_name(definition, key, return_class?)
+
+  def class_name(definition, key) when is_atom(key),
+    do: key |> Atom.to_string() |> (&class_name(definition, &1)).()
 
   def class_name(definition, key) do
     definition
@@ -175,6 +184,9 @@ defmodule ExCSSModules do
       nil
 
       iex> class_selector(%{ "hello" => "world"}, "hello")
+      ".world"
+
+      iex> class_selector(%{ "hello" => "world"}, :hello)
       ".world"
 
       iex> class_selector(%{ "hello" => "world", "foo" => "bar"}, ["hello", "foo"])

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -48,6 +48,9 @@ defmodule ExCSSModules do
   attribute. The `keys` argument is used to retrieve the class name or multiple
   class names with class_name/1.
 
+  Returns nil if `return_class?` is falsy. `return_class?` is optional and
+  truthy by default.
+
   Returns nil for a class_name that does not exist.
 
   ## Examples
@@ -55,81 +58,35 @@ defmodule ExCSSModules do
       iex> class(%{ "hello" => "world"}, "hello")
       {:safe, ~s(class="world")}
 
-      iex> class(%{"hello" => "world"}, "foo")
-      nil
-
-  """
-  def class(definition, keys) do
-    definition
-    |> class_name(keys)
-    |> class_attribute()
-  end
-
-  @doc """
-  If `return_class?` is truthy, reads the class definitions and maps them to a
-  class attribute. When `return_class?` is falsy returns nil.
-
-  ## Examples
-
-      iex> class(%{ "hello" => "world"}, "hello", true)
+      iex> class(%{ "hello" => "world"}, :hello, true)
       {:safe, ~s(class="world")}
 
       iex> class(%{ "hello" => "world"}, "hello", false)
       nil
 
+      iex> class(%{"hello" => "world"}, "foo")
+      nil
+
   """
-  def class(definition, keys, return_class?) do
+  def class(definition, keys, return_class? \\ true) do
     definition
     |> class_name(keys, return_class?)
     |> class_attribute()
   end
 
   @doc """
-  Returns the class name from the definition map if the last argument is truthy.
-  Returns nil if the last argument is falsy.
-
-  ## Examples
-
-      iex> class_name(%{"hello" => "world"}, "hello", true)
-      "world"
-
-      iex> class_name(%{"hello" => "world"}, "hello", "anything")
-      "world"
-
-      iex> class_name(%{"hello" => "world"}, :hello, true)
-      "world"
-
-      iex> class_name(%{"hello" => "world"}, "hello", false)
-      nil
-
-      iex> class_name(%{"hello" => "world"}, "hello", nil)
-      nil
-
-  """
-  def class_name(_, _, false), do: nil
-  def class_name(_, _, nil), do: nil
-  def class_name(definition, key, _), do: class_name(definition, key)
-
-  @doc """
   Returns the class name or class names from the definition map, concatenated as
   one string separated by spaces.
 
-  Second argument can be a string or atom name of the key, a tuple with
-  `{key, boolean}` or a list of keys or tuples.
+  Second argument `key` can be a string or atom name of the key, a tuple with
+  `{key, boolean}` or a list of either keys or tuples.
+
+  Returns nil if `return_class?` is falsy. `return_class?` is optional and
+  truthy by default.
+
+  Returns nil for a key that does not exist.
 
   ## Examples
-
-      iex> class_name(%{"hello" => "world"}, "hello")
-      "world"
-
-      iex> class_name(%{"hello" => "world"}, "foo")
-      nil
-
-      iex> class_name(%{"hello" => "world"}, {"hello", true})
-      "world"
-
-      iex> class_name(%{"hello" => "world"}, {"hello", false})
-      nil
 
       iex> class_name(%{"hello" => "world", "foo" => "bar"}, ["hello", "foo"])
       "world bar"
@@ -143,26 +100,53 @@ defmodule ExCSSModules do
       iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{:hello, true}, {:foo, false}])
       "world"
 
-      iex> class_name(%{"hello" => "world", "foo" => "bar"}, [{"hello", false}])
+      iex> class_name(%{"hello" => "world"}, "hello")
+      "world"
+
+      iex> class_name(%{"hello" => "world"}, :hello, true)
+      "world"
+
+      iex> class_name(%{"hello" => "world"}, "hello", "anything")
+      "world"
+
+      iex> class_name(%{"hello" => "world"}, {"hello", true})
+      "world"
+
+      iex> class_name(%{"hello" => "world"}, "hello", false)
+      nil
+
+      iex> class_name(%{"hello" => "world"}, {:hello, nil})
+      nil
+
+      iex> class_name(%{"hello" => "world"}, "foo")
       nil
 
       iex> class_name(%{}, "hello")
       nil
 
   """
-  def class_name(definition, keys) when is_list(keys) do
+  def class_name(definition, key, return_class? \\ true)
+
+  def class_name(_, _, false), do: nil
+  def class_name(_, _, nil), do: nil
+
+  def class_name(definition, keys, _) when is_list(keys) do
     keys
     |> Enum.map(&class_name(definition, &1))
     |> Enum.reject(&is_nil/1)
     |> join_class_name()
   end
 
-  def class_name(definition, {key, return_class?}), do: class_name(definition, key, return_class?)
+  def class_name(definition, {key, return_class?}, _),
+    do: class_name(definition, key, return_class?)
 
-  def class_name(definition, key) when is_atom(key),
-    do: key |> Atom.to_string() |> (&class_name(definition, &1)).()
+  def class_name(definition, key, _) when is_atom(key) do
+    key
+    |> Atom.to_string()
+    |> (&class_name(definition, &1)).()
+  end
 
-  def class_name(definition, key) do
+  def class_name(definition, key, _) do
     definition
     |> stylesheet()
     |> Map.get(key, nil)

--- a/lib/ex_css_modules/ex_css_modules.ex
+++ b/lib/ex_css_modules/ex_css_modules.ex
@@ -5,6 +5,9 @@ defmodule ExCSSModules do
   alias __MODULE__
   alias Phoenix.HTML
 
+  @type key :: String.t() | atom()
+  @type key_tuple :: {key, as_boolean(term())}
+
   @doc """
   Reads a valid stylesheet definition. Returns a map if the stylesheet is
   already a map. Reads the file if the stylesheet is a string. Returns an empty
@@ -28,6 +31,7 @@ defmodule ExCSSModules do
       %{}
 
   """
+  @spec stylesheet(String.t() | map()) :: map()
   def stylesheet(definition) when is_map(definition), do: definition
   def stylesheet(definition), do: read_stylesheet(definition)
 
@@ -64,10 +68,14 @@ defmodule ExCSSModules do
       iex> class(%{ "hello" => "world"}, "hello", false)
       nil
 
+      iex> class(%{ "hello" => "world"}, "hello", nil)
+      nil
+
       iex> class(%{"hello" => "world"}, "foo")
       nil
 
   """
+  @spec class(map(), key, as_boolean(term())) :: {:safe, iodata()} | nil
   def class(definition, keys, return_class? \\ true) do
     definition
     |> class_name(keys, return_class?)
@@ -125,6 +133,8 @@ defmodule ExCSSModules do
       nil
 
   """
+  @spec class_name(map(), key | key_tuple | [key, ...] | [key_tuple, ...], as_boolean(term())) ::
+          String.t() | nil
   def class_name(definition, key, return_class? \\ true)
 
   def class_name(_, _, false), do: nil
@@ -177,6 +187,7 @@ defmodule ExCSSModules do
       ".world.bar"
 
   """
+  @spec class_selector(String.t() | map(), key | [key, ...]) :: String.t()
   def class_selector(definition, keys) when is_list(keys) do
     keys
     |> Enum.map(&class_selector(definition, &1))


### PR DESCRIPTION
The atoms will be converted to string before retrieving it from a stylesheet definition.

~~circle CI will pass with errors in typespecs, need to fix~~ fixed